### PR TITLE
Add more Markdown support: list completion, indent, shortcuts, etc.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "monaco-editor": "^0.33.0",
+        "monaco-markdown": "^0.0.12",
         "throttle-debounce": "^5.0.0"
       },
       "devDependencies": {
@@ -1638,6 +1639,15 @@
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.33.0.tgz",
       "integrity": "sha512-VcRWPSLIUEgQJQIE0pVT8FcGBIgFoxz7jtqctE+IiCxWugD0DwgyQBcZBhdSrdMC84eumoqMZsGl2GTreOzwqw=="
     },
+    "node_modules/monaco-markdown": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/monaco-markdown/-/monaco-markdown-0.0.12.tgz",
+      "integrity": "sha512-KkGheL2pUazZJY2DfBqpHuMQOjILkbYGNtF5MzpT3ZWupKjunkpL7ByKTllBQGKKcVNt5nuRHl7YsKFskWlc6Q==",
+      "dependencies": {
+        "monaco-editor": "0.30.1",
+        "string-similarity": "^3.0.0"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -1907,6 +1917,11 @@
       "engines": {
         "node": ">= 0.3.0"
       }
+    },
+    "node_modules/string-similarity": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/string-similarity/-/string-similarity-3.0.0.tgz",
+      "integrity": "sha512-7kS7LyTp56OqOI2BDWQNVnLX/rCxIQn+/5M0op1WV6P8Xx6TZNdajpuqQdiJ7Xx+p1C5CsWMvdiBp9ApMhxzEQ=="
     },
     "node_modules/supports-color": {
       "version": "5.5.0",
@@ -3175,6 +3190,15 @@
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.33.0.tgz",
       "integrity": "sha512-VcRWPSLIUEgQJQIE0pVT8FcGBIgFoxz7jtqctE+IiCxWugD0DwgyQBcZBhdSrdMC84eumoqMZsGl2GTreOzwqw=="
     },
+    "monaco-markdown": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/monaco-markdown/-/monaco-markdown-0.0.12.tgz",
+      "integrity": "sha512-KkGheL2pUazZJY2DfBqpHuMQOjILkbYGNtF5MzpT3ZWupKjunkpL7ByKTllBQGKKcVNt5nuRHl7YsKFskWlc6Q==",
+      "requires": {
+        "monaco-editor": "^0.33.0",
+        "string-similarity": "^3.0.0"
+      }
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -3341,6 +3365,11 @@
       "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-0.2.6.tgz",
       "integrity": "sha512-ZRpmWyuCdg0TtNKk8bEqvm13oQvXMmzXDsfD4cBgcx5LouborvU5pm3JMkdTP3HcszyUI08AM1dHMXA5r2g6Sg==",
       "dev": true
+    },
+    "string-similarity": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/string-similarity/-/string-similarity-3.0.0.tgz",
+      "integrity": "sha512-7kS7LyTp56OqOI2BDWQNVnLX/rCxIQn+/5M0op1WV6P8Xx6TZNdajpuqQdiJ7Xx+p1C5CsWMvdiBp9ApMhxzEQ=="
     },
     "supports-color": {
       "version": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,12 @@
   },
   "dependencies": {
     "monaco-editor": "^0.33.0",
+    "monaco-markdown": "^0.0.12",
     "throttle-debounce": "^5.0.0"
+  },
+  "overrides": {
+    "monaco-markdown": {
+      "monaco-editor": "$monaco-editor"
+    }
   }
 }

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -1,0 +1,3 @@
+import { MonacoMarkdownExtension } from "monaco-markdown";
+
+export const MarkdownExtension = MonacoMarkdownExtension;

--- a/src/newtab.ts
+++ b/src/newtab.ts
@@ -1,5 +1,6 @@
 import "./style.css";
 import { monaco } from "./editor";
+import { MarkdownExtension } from "./extensions";
 import EditorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker";
 import { debounce } from "throttle-debounce";
 
@@ -29,6 +30,9 @@ const editor = monaco.editor.create(element, {
   quickSuggestions: false,
   wordWrap: "on",
 });
+
+const extension = new MarkdownExtension();
+extension.activate(editor);
 
 const debounceFunction = debounce(400, () => {
   const content = editor.getValue();


### PR DESCRIPTION
Hi @r7kamura 

Thank you for creating this chrome extension.
I wanna use like [vscode-markdown ](https://github.com/yzhang-gh/vscode-markdown ). so, I added [monaco-markdown](https://www.npmjs.com/package/monaco-markdown). If you like this, please merge.

![CleanShot20220721at183053](https://user-images.githubusercontent.com/24843808/180181121-a4ce54c8-de1e-471f-9d7c-4ff186870007.gif)

( I forgot to turn off Grammarly. Please ignore the Grammarly icon.)