### PR TITLE
Support Japanese manifest

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -1,0 +1,8 @@
+{
+  "extName": {
+    "message": "Editabro"
+  },
+  "extDescription": {
+    "message": "Editor in new tab."
+  }
+}

--- a/public/_locales/ja/messages.json
+++ b/public/_locales/ja/messages.json
@@ -1,0 +1,8 @@
+{
+  "extName": {
+    "message": "エディタブ郎"
+  },
+  "extDescription": {
+    "message": "新規タブをエディタにします"
+  }
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,7 @@
 {
-  "name": "Editabro",
-  "description": "Editor in new tab.",
+  "name": "__MSG_extName__",
+  "description": "__MSG_extDescription__",
+  "default_locale": "en",
   "version": "0.3.0",
   "manifest_version": 3,
   "icons": {


### PR DESCRIPTION
I think Japanese language support would improve googlability.

![image](https://user-images.githubusercontent.com/1443118/188430036-c5cf1094-112d-436a-afd3-625b322e1f48.png)
![image](https://user-images.githubusercontent.com/1443118/188430330-89c3c550-292d-40c7-938a-0a390118f39f.png)

https://developer.chrome.com/docs/extensions/reference/i18n/
